### PR TITLE
Make 'test as you commit' link future-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ has an extensive set of methods that can be used to write tests for the features
 
 ## How should my group go about producing tests for meeting CR exit criteria?
 ### Testing facilitator
-### Test as you commit (pointer event, whatwg, webperf)
+### Test as you commit
 
 ALL normative spec changes are generally expected to have a corresponding pull request in [web-platform-tests](https://github.com/w3c/web-platform-tests), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the proposed update.
 


### PR DESCRIPTION
This would be much nicer and future-proof:

https://github.com/w3c/testing-how-to/#test-as-you-commit

Compare:

https://github.com/w3c/testing-how-to#test-as-you-commit-pointer-event-whatwg-webperf

This section is expected to be referenced from many places when the test as you commit policy is popularized.

When this lands, you may want to do an in place fix to:
https://www.w3.org/2017/04/svg-2017.html#deliverables

Cc @sideshowbarker